### PR TITLE
fix: Show cursor when done showing progress and spinner

### DIFF
--- a/src/glitzer/codes.gleam
+++ b/src/glitzer/codes.gleam
@@ -10,4 +10,8 @@ pub const return_home_code = "\u{001b}[H"
 /// Print this code to return to the start of the line
 pub const return_line_start_code = "\r"
 
+/// Print this code to hide the cursor
 pub const hide_cursor_code = "\u{001b}[?25l"
+
+/// Print this code to show the cursor if it has been hidden
+pub const show_cursor_code = "\u{001b}[?25h"

--- a/src/glitzer/progress.gleam
+++ b/src/glitzer/progress.gleam
@@ -370,7 +370,7 @@ pub fn print_bar(bar bar: ProgressStyle) {
     |> string_builder.to_string
 
   let end = case bar.state.finished {
-    True -> "\n"
+    True -> "\n" <> codes.show_cursor_code
     False -> ""
   }
 

--- a/src/glitzer/spinner.gleam
+++ b/src/glitzer/spinner.gleam
@@ -299,7 +299,7 @@ pub fn finish(spinner s: SpinnerStyle) -> SpinnerStyle {
     option.None -> Nil
   }
   io.println(
-    codes.hide_cursor_code
+    codes.show_cursor_code
     <> codes.clear_line_code
     <> codes.return_line_start_code
     <> s.finish_text,


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently `glitzer` hides the cursor and does not show it again when it's done.
Issue Number: #21

## What is the new behavior?

- Print escape sequence to show cursor in spinner and progress bar and show cursor again

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A