### PR TITLE
fix: more deprecation warnings for Gleam stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ You can access the progress bars with `import glitzer/progress`.
 
 ```gleam
 import gleam/int
-import gleam/iterator
+import gleam/yielder
 
 import glitzer/progress
 
 pub fn main() {
-    let bar = 
-        progress.new_bar() 
+    let bar =
+        progress.new_bar()
         |> progress.with_length(100)
         |> progress.with_fill(progress.char_from_string("+"))
         |> progress.with_empty(progress.char_from_string("-"))
         |> progress.with_left_text("Doing stuff: ")
-    iterator.range(1, 100)
-    |> progress.each_iterator(bar, fn(bar, i) {
+    yielder.range(1, 100)
+    |> progress.each_yielder(bar, fn(bar, i) {
         progress.with_left_text(bar, int.to_string(i) <> " ")
         |> progress.print_bar
         // do some other stuff here
@@ -117,7 +117,7 @@ fn do_stuff(bar, count) {
             // some heavy lifting
             do_stuff(bar, count + 1)
         }
-       False -> Nil 
+       False -> Nil
     }
 }
 ```
@@ -140,7 +140,7 @@ pub fn main() {
     |> spinner.spin // this will continuously spin your spinner
 
     // do some stuff
-    
+
     // update the text
     spinner.with_left_text(s, "Now imma spin some more :] ")
     |> spinner.with_frame_transform(fn(s) {"<" <> s <> ">"})
@@ -166,7 +166,7 @@ New code and pull requests are greatly appreciated! If you want to contribute,
 check the [contributing guidelines](#contributing) and submit a PR :3
 
 If you have any questions, feel free to
-[create a question]((https://github.com/miampf/glitzer/issues/new?assignees=&labels=question&template=04_SUPPORT_QUESTION.md&title=support%3A+))!
+[create a question](<(https://github.com/miampf/glitzer/issues/new?assignees=&labels=question&template=04_SUPPORT_QUESTION.md&title=support%3A+)>)!
 Please note that it may take some time for me to respond. I am not paid for
 doing this and do have a private life (surprise!) :]
 

--- a/birdie_snapshots/test_progress_map2_iterator.accepted
+++ b/birdie_snapshots/test_progress_map2_iterator.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.4
+title: Test progress.map2_iterator
+file: ./test/glitzer_test.gleam
+test_name: progress_map2_iterator_test
+---
+Iterator(//fn() { ... })

--- a/birdie_snapshots/test_progress_map2_iterator.accepted
+++ b/birdie_snapshots/test_progress_map2_iterator.accepted
@@ -1,7 +1,0 @@
----
-version: 1.1.6
-title: Test progress.map2_iterator
-file: ./test/glitzer_test.gleam
-test_name: progress_map2_iterator_test
----
-Iterator(//fn() { ... })

--- a/birdie_snapshots/test_progress_map2_yielder.accepted
+++ b/birdie_snapshots/test_progress_map2_yielder.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.4
+title: Test progress.map2_yielder
+file: ./test/glitzer_test.gleam
+test_name: progress_map2_yielder_test
+---
+Yielder(//fn() { ... })

--- a/birdie_snapshots/test_progress_map_iterator.accepted
+++ b/birdie_snapshots/test_progress_map_iterator.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.4
+title: Test progress.map_iterator
+file: ./test/glitzer_test.gleam
+test_name: progress_map_iterator_test
+---
+Iterator(//fn() { ... })

--- a/birdie_snapshots/test_progress_map_iterator.accepted
+++ b/birdie_snapshots/test_progress_map_iterator.accepted
@@ -1,7 +1,0 @@
----
-version: 1.1.6
-title: Test progress.map_iterator
-file: ./test/glitzer_test.gleam
-test_name: progress_map_iterator_test
----
-Iterator(//fn() { ... })

--- a/birdie_snapshots/test_progress_map_yielder.accepted
+++ b/birdie_snapshots/test_progress_map_yielder.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.2.4
+title: Test progress.map_yielder
+file: ./test/glitzer_test.gleam
+test_name: progress_map_yielder_test
+---
+Yielder(//fn() { ... })

--- a/gleam.toml
+++ b/gleam.toml
@@ -20,6 +20,7 @@ gleam_community_ansi = ">= 1.4.0 and < 2.0.0"
 glearray = ">= 1.0.0 and < 2.0.0"
 repeatedly = ">= 2.1.1 and < 3.0.0"
 gleam_community_colour = ">= 1.4.0 and < 2.0.0"
+gleam_yielder = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -12,7 +12,8 @@ packages = [
   { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
   { name = "gleam_erlang", version = "0.30.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "760618870AE4A497B10C73548E6E44F43B76292A54F0207B3771CBB599C675B4" },
   { name = "gleam_json", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "0A57FB5666E695FD2BEE74C0428A98B0FC11A395D2C7B4CDF5E22C5DD32C74C6" },
-  { name = "gleam_stdlib", version = "0.43.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "69EF22E78FDCA9097CBE7DF91C05B2A8B5436826D9F66680D879182C0860A747" },
+  { name = "gleam_stdlib", version = "0.44.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "A6E55E309A6778206AAD4038D9C49E15DF71027A1DB13C6ADA06BFDB6CF1260E" },
+  { name = "gleam_yielder", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "44C8DE196A10634667F5F7B93128A997B35DFD37E26F775D749BC6A239B499A8" },
   { name = "glearray", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glearray", source = "hex", outer_checksum = "B99767A9BC63EF9CC8809F66C7276042E5EFEACAA5B25188B552D3691B91AC6D" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
@@ -29,6 +30,7 @@ birdie = { version = ">= 1.1.6 and < 2.0.0" }
 gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0" }
 gleam_community_colour = { version = ">= 1.4.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_yielder = { version = ">= 1.0.0 and < 2.0.0" }
 glearray = { version = ">= 1.0.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 pprint = { version = ">= 1.0.3 and < 2.0.0" }

--- a/src/glitzer/progress.gleam
+++ b/src/glitzer/progress.gleam
@@ -48,6 +48,7 @@
 /// }
 /// ```
 import gleam/io
+import gleam/iterator.{type Iterator}
 import gleam/option.{type Option}
 import gleam/string
 import gleam/string_tree.{type StringTree}
@@ -441,7 +442,71 @@ fn get_finished_fill(fill: StringTree, bar: ProgressStyle) -> StringTree {
   }
 }
 
-/// Map an yielder to a function with a bar that ticks every run of the
+/// Map an iterator to a function with a bar that ticks every run of the
+/// function.
+///
+/// <details>
+/// <summary>Example:</summary>
+///
+/// ```gleam
+/// import glitzer/progress
+///
+/// fn example(bar) {
+///   iterator.range(0, 100)
+///   |> progress.map_iterator(fn(bar, element) {
+///     progress.print_bar(bar)
+///     // do some heavy calculations here >:)
+///   })
+/// }
+/// ```
+///
+/// </details>
+@deprecated("`map_iterator` was deprecated and will be removed in the next release. Use `map_yielder` instead.")
+pub fn map_iterator(
+  over i: Iterator(a),
+  bar bar: ProgressStyle,
+  with fun: fn(ProgressStyle, a) -> b,
+) -> Iterator(b) {
+  iterator.index(i)
+  |> iterator.map(fn(pair) {
+    let #(el, i) = pair
+    tick_bar_by_i(bar, i)
+    |> fun(el)
+  })
+}
+
+@deprecated("`map2_iterator` was deprecated and will be removed in the next release. Use `map2_yielder` instead.")
+pub fn map2_iterator(
+  iterator1 i1: Iterator(a),
+  iterator2 i2: Iterator(b),
+  bar bar: ProgressStyle,
+  with fun: fn(ProgressStyle, a, b) -> c,
+) -> Iterator(c) {
+  iterator.zip(i1, i2)
+  |> iterator.index
+  |> iterator.map(fn(pair) {
+    let #(pair, i) = pair
+    let #(el1, el2) = pair
+    tick_bar_by_i(bar, i)
+    |> fun(el1, el2)
+  })
+}
+
+@deprecated("`each_iterator` was deprecated and will be removed in the next release. Use `each_yielder` instead.")
+pub fn each_iterator(
+  over i: Iterator(a),
+  bar bar: ProgressStyle,
+  with fun: fn(ProgressStyle, a) -> b,
+) -> Nil {
+  iterator.index(i)
+  |> iterator.each(fn(pair) {
+    let #(el, i) = pair
+    tick_bar_by_i(bar, i)
+    |> fun(el)
+  })
+}
+
+/// Map a yielder to a function with a bar that ticks every run of the
 /// function.
 ///
 /// <details>

--- a/src/glitzer/progress.gleam
+++ b/src/glitzer/progress.gleam
@@ -48,10 +48,10 @@
 /// }
 /// ```
 import gleam/io
-import gleam/yielder.{type Yielder}
 import gleam/option.{type Option}
 import gleam/string
 import gleam/string_tree.{type StringTree}
+import gleam/yielder.{type Yielder}
 
 import gleam_community/ansi
 

--- a/src/glitzer/progress.gleam
+++ b/src/glitzer/progress.gleam
@@ -7,7 +7,7 @@
 ///
 /// ```gleam
 /// import gleam/int
-/// import gleam/iterator
+/// import gleam/yielder
 /// 
 /// import glitzer/progress
 /// 
@@ -18,8 +18,8 @@
 ///         |> progress.with_fill(progress.char_from_string("+"))
 ///         |> progress.with_empty(progress.char_from_string("-"))
 ///         |> progress.with_left_text("Doing stuff: ")
-///     iterator.range(1, 100)
-///     |> progress.each_iterator(bar, fn(bar, i) {
+///     yielder.range(1, 100)
+///     |> progress.each_yielder(bar, fn(bar, i) {
 ///         progress.with_left_text(bar, int.to_string(i) <> " ")
 ///         |> progress.print_bar
 ///         // do some other stuff here
@@ -48,7 +48,7 @@
 /// }
 /// ```
 import gleam/io
-import gleam/iterator.{type Iterator}
+import gleam/yielder.{type Yielder}
 import gleam/option.{type Option}
 import gleam/string
 import gleam/string_tree.{type StringTree}
@@ -441,7 +441,7 @@ fn get_finished_fill(fill: StringTree, bar: ProgressStyle) -> StringTree {
   }
 }
 
-/// Map an iterator to a function with a bar that ticks every run of the
+/// Map an yielder to a function with a bar that ticks every run of the
 /// function.
 ///
 /// <details>
@@ -451,8 +451,8 @@ fn get_finished_fill(fill: StringTree, bar: ProgressStyle) -> StringTree {
 /// import glitzer/progress
 ///
 /// fn example(bar) {
-///   iterator.range(0, 100)
-///   |> progress.map_iterator(fn(bar, element) {
+///   yielder.range(0, 100)
+///   |> progress.map_yielder(fn(bar, element) {
 ///     progress.print_bar(bar)
 ///     // do some heavy calculations here >:)
 ///   })
@@ -460,13 +460,13 @@ fn get_finished_fill(fill: StringTree, bar: ProgressStyle) -> StringTree {
 /// ```
 ///
 /// </details>
-pub fn map_iterator(
-  over i: Iterator(a),
+pub fn map_yielder(
+  over y: Yielder(a),
   bar bar: ProgressStyle,
   with fun: fn(ProgressStyle, a) -> b,
-) -> Iterator(b) {
-  iterator.index(i)
-  |> iterator.map(fn(pair) {
+) -> Yielder(b) {
+  yielder.index(y)
+  |> yielder.map(fn(pair) {
     let #(el, i) = pair
     tick_bar_by_i(bar, i)
     |> fun(el)
@@ -480,15 +480,15 @@ fn tick_bar_by_i(bar, i) -> ProgressStyle {
   }
 }
 
-pub fn map2_iterator(
-  iterator1 i1: Iterator(a),
-  iterator2 i2: Iterator(b),
+pub fn map2_yielder(
+  yielder1 y1: Yielder(a),
+  yielder2 y2: Yielder(b),
   bar bar: ProgressStyle,
   with fun: fn(ProgressStyle, a, b) -> c,
-) -> Iterator(c) {
-  iterator.zip(i1, i2)
-  |> iterator.index
-  |> iterator.map(fn(pair) {
+) -> Yielder(c) {
+  yielder.zip(y1, y2)
+  |> yielder.index
+  |> yielder.map(fn(pair) {
     let #(pair, i) = pair
     let #(el1, el2) = pair
     tick_bar_by_i(bar, i)
@@ -496,13 +496,13 @@ pub fn map2_iterator(
   })
 }
 
-pub fn each_iterator(
-  over i: Iterator(a),
+pub fn each_yielder(
+  over y: Yielder(a),
   bar bar: ProgressStyle,
   with fun: fn(ProgressStyle, a) -> b,
 ) -> Nil {
-  iterator.index(i)
-  |> iterator.each(fn(pair) {
+  yielder.index(y)
+  |> yielder.each(fn(pair) {
     let #(el, i) = pair
     tick_bar_by_i(bar, i)
     |> fun(el)

--- a/test/glitzer_test.gleam
+++ b/test/glitzer_test.gleam
@@ -1,3 +1,4 @@
+import gleam/iterator
 import gleam/yielder
 import gleeunit
 
@@ -147,6 +148,23 @@ pub fn progress_finish_test() {
   |> progress.finish
   |> pprint.format
   |> birdie.snap(title: "Test progresss.finish")
+}
+
+pub fn progress_map_iterator_test() {
+  let bar = progress.new_bar()
+  iterator.empty()
+  |> progress.map_iterator(bar, fn(_, _) { progress.print_bar(bar) })
+  |> pprint.format
+  |> birdie.snap(title: "Test progress.map_iterator")
+}
+
+pub fn progress_map2_iterator_test() {
+  let bar = progress.new_bar()
+  let i1 = iterator.empty()
+  let i2 = iterator.empty()
+  progress.map2_iterator(i1, i2, bar, fn(_, _, _) { progress.print_bar(bar) })
+  |> pprint.format
+  |> birdie.snap(title: "Test progress.map2_iterator")
 }
 
 pub fn progress_map_yielder_test() {

--- a/test/glitzer_test.gleam
+++ b/test/glitzer_test.gleam
@@ -1,4 +1,4 @@
-import gleam/iterator
+import gleam/yielder
 import gleeunit
 
 import birdie
@@ -149,21 +149,21 @@ pub fn progress_finish_test() {
   |> birdie.snap(title: "Test progresss.finish")
 }
 
-pub fn progress_map_iterator_test() {
+pub fn progress_map_yielder_test() {
   let bar = progress.new_bar()
-  iterator.empty()
-  |> progress.map_iterator(bar, fn(_, _) { progress.print_bar(bar) })
+  yielder.empty()
+  |> progress.map_yielder(bar, fn(_, _) { progress.print_bar(bar) })
   |> pprint.format
-  |> birdie.snap(title: "Test progress.map_iterator")
+  |> birdie.snap(title: "Test progress.map_yielder")
 }
 
-pub fn progress_map2_iterator_test() {
+pub fn progress_map2_yielder_test() {
   let bar = progress.new_bar()
-  let i1 = iterator.empty()
-  let i2 = iterator.empty()
-  progress.map2_iterator(i1, i2, bar, fn(_, _, _) { progress.print_bar(bar) })
+  let y1 = yielder.empty()
+  let y2 = yielder.empty()
+  progress.map2_yielder(y1, y2, bar, fn(_, _, _) { progress.print_bar(bar) })
   |> pprint.format
-  |> birdie.snap(title: "Test progress.map2_iterator")
+  |> birdie.snap(title: "Test progress.map2_yielder")
 }
 
 pub fn spinner_frames_from_list_test() {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Hello, I'm back :) The stdlib deprecated more stuff

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Fixing deprecation warnings

## What is the current behavior?

The code references deprecated stdlib types and values
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The code now uses the new names and modules for those types/values

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

The current version of `glitzer` uses `gleam/iterator` which is now deprecated in favour of `gleam/yielder`. It uses it in the `map_iterator`, `map2_iterator` and `each_iterator` functions. I have renamed these to `*_yielder` as that is a better description of their new behaviour. Users would have to use the new function names, and use the `Yielder` type instead of `Iterator`.

If you don't want to release a breaking change just yet, we could introduce these new functions in addition to the existing ones, but deprecate the ones that still use `Iterator`, removing them at a later date.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
