### PR TITLE
deps: Remove `*_iterator` functions

### DIFF
--- a/birdie_snapshots/test_progress_map2_iterator.accepted
+++ b/birdie_snapshots/test_progress_map2_iterator.accepted
@@ -1,7 +1,0 @@
----
-version: 1.2.4
-title: Test progress.map2_iterator
-file: ./test/glitzer_test.gleam
-test_name: progress_map2_iterator_test
----
-Iterator(//fn() { ... })

--- a/birdie_snapshots/test_progress_map_iterator.accepted
+++ b/birdie_snapshots/test_progress_map_iterator.accepted
@@ -1,7 +1,0 @@
----
-version: 1.2.4
-title: Test progress.map_iterator
-file: ./test/glitzer_test.gleam
-test_name: progress_map_iterator_test
----
-Iterator(//fn() { ... })

--- a/src/glitzer/progress.gleam
+++ b/src/glitzer/progress.gleam
@@ -48,7 +48,6 @@
 /// }
 /// ```
 import gleam/io
-import gleam/iterator.{type Iterator}
 import gleam/option.{type Option}
 import gleam/string
 import gleam/string_tree.{type StringTree}
@@ -473,70 +472,6 @@ fn get_finished_fill(fill: StringTree, bar: ProgressStyle) -> StringTree {
     // build the unfinished style
     False -> string_tree.append(fill, bar.fill.char)
   }
-}
-
-/// Map an iterator to a function with a bar that ticks every run of the
-/// function.
-///
-/// <details>
-/// <summary>Example:</summary>
-///
-/// ```gleam
-/// import glitzer/progress
-///
-/// fn example(bar) {
-///   iterator.range(0, 100)
-///   |> progress.map_iterator(fn(bar, element) {
-///     progress.print_bar(bar)
-///     // do some heavy calculations here >:)
-///   })
-/// }
-/// ```
-///
-/// </details>
-@deprecated("`map_iterator` was deprecated and will be removed in the next release. Use `map_yielder` instead.")
-pub fn map_iterator(
-  over i: Iterator(a),
-  bar bar: ProgressStyle,
-  with fun: fn(ProgressStyle, a) -> b,
-) -> Iterator(b) {
-  iterator.index(i)
-  |> iterator.map(fn(pair) {
-    let #(el, i) = pair
-    tick_bar_by_i(bar, i)
-    |> fun(el)
-  })
-}
-
-@deprecated("`map2_iterator` was deprecated and will be removed in the next release. Use `map2_yielder` instead.")
-pub fn map2_iterator(
-  iterator1 i1: Iterator(a),
-  iterator2 i2: Iterator(b),
-  bar bar: ProgressStyle,
-  with fun: fn(ProgressStyle, a, b) -> c,
-) -> Iterator(c) {
-  iterator.zip(i1, i2)
-  |> iterator.index
-  |> iterator.map(fn(pair) {
-    let #(pair, i) = pair
-    let #(el1, el2) = pair
-    tick_bar_by_i(bar, i)
-    |> fun(el1, el2)
-  })
-}
-
-@deprecated("`each_iterator` was deprecated and will be removed in the next release. Use `each_yielder` instead.")
-pub fn each_iterator(
-  over i: Iterator(a),
-  bar bar: ProgressStyle,
-  with fun: fn(ProgressStyle, a) -> b,
-) -> Nil {
-  iterator.index(i)
-  |> iterator.each(fn(pair) {
-    let #(el, i) = pair
-    tick_bar_by_i(bar, i)
-    |> fun(el)
-  })
 }
 
 /// Map a yielder to a function with a bar that ticks every run of the

--- a/test/glitzer_test.gleam
+++ b/test/glitzer_test.gleam
@@ -1,4 +1,3 @@
-import gleam/iterator
 import gleam/yielder
 import gleeunit
 import glitzer/multi
@@ -149,23 +148,6 @@ pub fn progress_finish_test() {
   |> progress.finish
   |> pprint.format
   |> birdie.snap(title: "Test progresss.finish")
-}
-
-pub fn progress_map_iterator_test() {
-  let bar = progress.new_bar()
-  iterator.empty()
-  |> progress.map_iterator(bar, fn(_, _) { progress.print_bar(bar) })
-  |> pprint.format
-  |> birdie.snap(title: "Test progress.map_iterator")
-}
-
-pub fn progress_map2_iterator_test() {
-  let bar = progress.new_bar()
-  let i1 = iterator.empty()
-  let i2 = iterator.empty()
-  progress.map2_iterator(i1, i2, bar, fn(_, _, _) { progress.print_bar(bar) })
-  |> pprint.format
-  |> birdie.snap(title: "Test progress.map2_iterator")
 }
 
 pub fn progress_map_yielder_test() {


### PR DESCRIPTION
Remove *_iterator functions to enable glitzer to run with gleam_stdlib>0.44.0

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently it's impossible to run glitzer woth gleam_stdlib>0.44.0
Issue Number: #33 

## What is the new behavior?

- It's possible to install glitzer with gleam_stdlib >0.44.0

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Applications should use *_yielder functions.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
